### PR TITLE
docs: delete unnecessary url prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Usage
 
-Pic smaller has been deployed to [`vercel`](https://vercel.com/), you can use it by visiting the URL [https://pic-smaller.vercel.app](pic-smaller.vercel.app). Due to the GFW, Chinese users can use it by visiting the URL [https://txx.cssrefs.com](https://txx.cssrefs.com)
+Pic smaller has been deployed to [`vercel`](https://vercel.com/), you can use it by visiting the URL [pic-smaller.vercel.app](pic-smaller.vercel.app). Due to the GFW, Chinese users can use it by visiting the URL [txx.cssrefs.com](https://txx.cssrefs.com)
 
 ## Develop
 
@@ -36,5 +36,5 @@ npm run dev
 
 ## Thanks
 
-- [https://github.com/antelle/wasm-image-compressor](https://github.com/antelle/wasm-image-compressor) Provides PNG image compression implementation based on Webassembly
-- [https://github.com/renzhezhilu/gifsicle-wasm-browser](https://github.com/renzhezhilu/gifsicle-wasm-browser) Provides Gif image compression implementation based on Webassembly
+- [wasm-image-compressor](https://github.com/antelle/wasm-image-compressor) Provides PNG image compression implementation based on Webassembly
+- [gifsicle-wasm-browser](https://github.com/renzhezhilu/gifsicle-wasm-browser) Provides Gif image compression implementation based on Webassembly


### PR DESCRIPTION
This pull request proposes the removal of the "https" prefix information from the document. The inclusion of this prefix is redundant and does not contribute to the clarity or functionality of the content. By eliminating this unnecessary detail, we aim to streamline the document and enhance its readability.