### PR TITLE
fix: Loading animation opacity order is reversed

### DIFF
--- a/src/components/Indicator/index.module.scss
+++ b/src/components/Indicator/index.module.scss
@@ -60,7 +60,7 @@ $barColor: #444;
     }
     @for $index from 1 through $barNum {
       $rotate: math.div(360deg, $barNum) * ($index - 1);
-      $opacity: math.div($barNum - $index + 1, $barNum);
+      $opacity: math.div($index, $barNum);
       &:nth-child(#{$index}) {
         transform: rotate($rotate);
         &::after,


### PR DESCRIPTION
The original opacity order for the loading animation was incorrect.
Previously, the opacity increased from high to low clockwise.
This commit changes the opacity to increase from low to high clockwise,
while maintaining the clockwise rotation.