### PR TITLE
Refactor: Remove unnecessary styles in SCSS

### DIFF
--- a/src/components/Indicator/index.module.scss
+++ b/src/components/Indicator/index.module.scss
@@ -55,8 +55,6 @@ $barColor: #444;
       width: $barWidth;
       height: $barHeight;
       background-color: $barColor;
-      // $radius: math.div($barWidth, 2);
-      // border-radius: $radius $radius 0 0;
     }
     @for $index from 1 through $barNum {
       $rotate: math.div(360deg, $barNum) * ($index - 1);

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,7 +1,6 @@
 @import "antd/dist/reset.css";
 
 .__initial {
-  width: 100vw;
   height: 100vh;
   img {
     width: 30px;


### PR DESCRIPTION
This pull request simplifies the SCSS styling to enhance code readability and maintainability. Specific changes are as follows:

1. Removed the unnecessary `width: 100vw` setting in `src/main.scss`. Block-level elements are full-width by default, so this setting was redundant.
2. Removed unused comments in `src/components/Indicator/index.module.scss`. These comments were previously used for debugging and are no longer needed.

These changes aim to streamline style definitions, making the code cleaner and easier to understand.
