### PR TITLE
chore: remove 'git add .' from pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,2 @@
 npm run lint
 npm run format
-git add .


### PR DESCRIPTION
This allows for more granular control over which files are included in a commit, making commits more focused and orthogonal.