### PR TITLE
Refactor: Cleanup and Rename Router Initialization Logic

### DIFF
--- a/src/Initial.tsx
+++ b/src/Initial.tsx
@@ -2,7 +2,7 @@ import { observer } from "mobx-react-lite";
 import { Flex, Typography } from "antd";
 import { useEffect } from "react";
 import { locales, modules } from "./modules";
-import { initHistoryLogic } from "./history";
+import { initRouter } from "./history";
 import { gstate } from "./global";
 import { Indicator } from "./components/Indicator";
 import { avifCheck } from "./engines/support";
@@ -25,7 +25,7 @@ export const Initial = observer(() => {
       }
       loadList.push(avifCheck());
       await Promise.all(loadList);
-      initHistoryLogic();
+      initRouter();
     })();
   }, []);
 

--- a/src/history.tsx
+++ b/src/history.tsx
@@ -5,23 +5,28 @@ import { modules } from "./modules";
 
 export const history = createBrowserHistory();
 
+type Params = Record<string, string | number> | null;
+
 export function goto(
   pathname: string = "/",
-  params?: Record<string, string | number> | null,
+  params?: Params,
   type: string = "push",
 ) {
-  let query = "";
-  if (params) {
-    const search = new URLSearchParams();
-    for (const key in params) {
-      search.append(key, String(params[key]));
-    }
-    query = search.toString();
-  }
-  if (query) {
-    pathname += "?" + query;
-  }
+  pathname += buildQueryString(params);
+  navigate(pathname, type);
+}
 
+function buildQueryString(params?: Params) {
+  if (!params) return "";
+  const search = new URLSearchParams();
+  for (const key in params) {
+    search.append(key, String(params[key]));
+  }
+  const query = search.toString();
+  return query ? `?${query}` : "";
+}
+
+function navigate(pathname: string, type: string): void {
   if (type === "push") {
     history.push(pathname);
   } else if (type === "replace") {

--- a/src/history.tsx
+++ b/src/history.tsx
@@ -19,9 +19,11 @@ export function goto(
 function buildQueryString(params?: Params) {
   if (!params) return "";
   const search = new URLSearchParams();
-  for (const key in params) {
-    search.append(key, String(params[key]));
-  }
+
+  Object.entries(params).forEach(([key, value]) => {
+    search.append(key, String(value));
+  });
+
   const query = search.toString();
   return query ? `?${query}` : "";
 }

--- a/src/history.tsx
+++ b/src/history.tsx
@@ -38,7 +38,7 @@ export function initRouter() {
   showPageByPath(history.location.pathname);
 }
 
-export async function showPageByPath(pathname: string) {
+async function showPageByPath(pathname: string) {
   pathname = normalize(pathname);
   if (!pathname) {
     pathname = "home";

--- a/src/history.tsx
+++ b/src/history.tsx
@@ -33,23 +33,23 @@ export function goto(
 
 export function initRouter() {
   history.listen(({ location }) => {
-    showPageByPath(location.pathname);
+    handleRouteChange(location.pathname);
   });
-  showPageByPath(history.location.pathname);
+  handleRouteChange(history.location.pathname);
 }
 
-async function showPageByPath(pathname: string) {
-  pathname = normalize(pathname);
-  if (!pathname) {
-    pathname = "home";
-  }
-  gstate.pathname = pathname;
+async function handleRouteChange(pathname: string) {
+  gstate.pathname = normalize(pathname) || "home";
+  gstate.page = await loadPageComponent(gstate.pathname);
+}
+
+async function loadPageComponent(pathname: string) {
   try {
     const importer = modules[`/src/pages/${pathname}/index.tsx`]();
     const result = await importer;
-    gstate.page = <result.default />;
+    return <result.default />;
   } catch (error) {
     const error404 = await import(`@/pages/error404/index.tsx`);
-    gstate.page = <error404.default />;
+    return <error404.default />;
   }
 }

--- a/src/history.tsx
+++ b/src/history.tsx
@@ -31,7 +31,7 @@ export function goto(
   }
 }
 
-export function initHistoryLogic() {
+export function initRouter() {
   history.listen(({ location }) => {
     showPageByPath(location.pathname);
   });


### PR DESCRIPTION
## Overview
This pull request includes two refactoring changes aimed at improving the clarity and structure of the routing logic within our codebase. The changes involve removing unnecessary `export` keywords and renaming functions to better reflect their purposes.

## Changes

1. **Remove Unnecessary Export**
   - The `showPageByPath` function in `src/history.tsx` was previously exported but is now used only within the module. This commit removes the `export` keyword, simplifying the interface and reducing potential external dependencies.
   - Commit: `refactor: del unnecessary 'export' for 'showPageByPath'`

2. **Rename Function for Clarity**
   - The function initially named `initHistoryLogic` has been renamed to `initRouter` to more accurately describe its role in initializing the routing system.
   - This change affects both `src/Initial.tsx` and `src/history.tsx`, updating import statements and function calls to reflect the new name.
   - Commit: `refactor: rename initHistoryLogic to initRouter`

## Rationale
These changes are intended to enhance the readability and maintainability of our routing logic. By removing unnecessary exports, we keep our module interfaces clean and focused. Renaming `initHistoryLogic` to `initRouter` provides clarity on the function's purpose, making the codebase easier to understand and navigate for new developers and reviewers alike.

Please review the proposed changes and provide feedback or approval at your earliest convenience. Thank you!
