### PR TITLE
feat: lightweight Docker images using Nginx

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .vscode
-dist
 docs
 node_modules
 

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,22 @@
+# -------------------Desciption---------------------
+
+# FROM nginx:alpine-slim: Uses the alpine-slim nginx image as the base image.
+# COPY nginx.conf /etc/nginx/conf.d/default.conf: Copies the nginx.conf file to the /etc/nginx/conf.d directory in the container, serving as the nginx configuration file.
+# COPY dist /usr/share/nginx/html: Copies the contents of the dist directory to the /usr/share/nginx/html directory in the container, which serves as nginx's static file directory.
+# EXPOSE 3000: Declares that the container is listening on port 3000.
+# CMD ["nginx", "-g", "daemon off"]: Runs the nginx command with the parameters -g daemon off when the container starts, indicating nginx should start in the foreground.
+
+# -------------------Usage--------------------
+
+# $ docker build -f Dockerfile.slim -t picsmaller-slim .
+# $ docker run -d -p 9000:3000 picsmaller-slim
+
+FROM nginx:alpine-slim
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+COPY dist /usr/share/nginx/html
+
+EXPOSE 3000
+
+CMD ["nginx", "-g", "daemon off"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 3000;
+    server_name localhost;
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
1. 使用nginx制作的docker镜像体积大小为16MB，对比原来的node.js制作的镜像体积大小为130MB，镜像的体积大小减少了接近8倍
2. 使用Dockerfile.slim制作的瘦身镜像可以满足对小体积镜像的需要