### PR TITLE
fix: nginx image startup command error

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -19,4 +19,4 @@ COPY dist /usr/share/nginx/html
 
 EXPOSE 3000
 
-CMD ["nginx", "-g", "daemon off"]
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
A semicolon is missing from the nginx image startup command

```
/docker-entrypoint.sh: Configuration complete; ready for start up
[emerg] 1#1: unexpected end of parameter, expecting ";" in command line
nginx: [emerg] unexpected end of parameter, expecting ";" in command line
```
